### PR TITLE
fix: lib_name should replace hyphens

### DIFF
--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -141,15 +141,16 @@ fn run_for_crate(
         }
     }
 
+    let crate_name = lib.name.replace('-', "_");
     for target in &targets {
-        build_with_output(target, &lib.name, mode, lib_type, config)?;
+        build_with_output(target, &crate_name, mode, lib_type, config)?;
     }
 
-    generate_bindings_with_output(&targets, &lib.name, mode, lib_type, config)?;
+    generate_bindings_with_output(&targets, &crate_name, mode, lib_type, config)?;
 
     recreate_output_dir(&package_name).expect("Could not create package output directory!");
-    create_xcframework_with_output(&targets, &lib.name, &package_name, mode, lib_type, config)?;
-    create_package_with_output(&package_name, &lib.name, disable_warnings, config)?;
+    create_xcframework_with_output(&targets, &crate_name, &package_name, mode, lib_type, config)?;
+    create_package_with_output(&package_name, &crate_name, disable_warnings, config)?;
 
     Ok(())
 }


### PR DESCRIPTION
cargo has a special flag to replace hyphens with underscores for output's name, which is always true for non-binary crate type.

[uplift_filename](https://github.com/rust-lang/cargo/blob/463f30742514ad54dfe24b2c3e151bf5b1c2f7c9/src/cargo/core/compiler/build_context/target_info.rs#L120C17-L126)
![image](https://github.com/antoniusnaumann/cargo-swift/assets/656711/d82a0ca3-5832-45fc-bba6-801970417f3f)

[crate_name](https://github.com/rust-lang/cargo/blob/463f30742514ad54dfe24b2c3e151bf5b1c2f7c9/src/cargo/core/manifest.rs#L793-L795)
![image](https://github.com/antoniusnaumann/cargo-swift/assets/656711/e650b1d5-e97b-4908-98fb-dcdd3f8d080d)
