### PR TITLE
Use the default Binding Generator

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -2,7 +2,7 @@ use std::fs::{self, create_dir};
 
 use crate::Result;
 use camino::Utf8Path;
-use uniffi_bindgen::bindings::swift::gen_swift::SwiftBindingGenerator;
+use uniffi_bindgen::{bindings::TargetLanguage, BindingGeneratorDefault};
 
 use crate::recreate_dir;
 
@@ -19,7 +19,10 @@ pub fn generate_bindings(lib_path: &Utf8Path, crate_name: &str) -> Result<()> {
     uniffi_bindgen::library_mode::generate_bindings(
         lib_path,
         Some(crate_name.to_owned()),
-        &SwiftBindingGenerator {},
+        &BindingGeneratorDefault {
+            target_languages: vec![TargetLanguage::Swift],
+            try_format_code: false,
+        },
         None,
         out_dir,
         false,


### PR DESCRIPTION
The swift binding generator doesn't seem to take into consideration the uniffi.toml file when generating the configuration. Use the default generator instead, while explicitly specifying swift as targeted language.

This can be tested with a simple `uniffi.toml` file for Url bindings:
```
[bindings.swift.custom_types.Url]
# Name of the type in the Swift code
type_name = "URL"
# Modules that need to be imported
imports = ["Foundation"]
# Functions to convert between strings and URLs
into_custom = "URL(string: {})!"
from_custom = "String(describing: {})"
```
The generated .swift file won't use the URL from swift, but stay back to the default type value implemented in the code (i.e. `String`)