### PR TITLE
Bundle all headers and swift files for multi-crate UniFFI setups

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,9 +2,9 @@ name: Examples
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,23 +13,25 @@ jobs:
   tests:
     strategy:
       matrix:
-        path: [
-            './swift-examples/hello-world/greeter',
-            './swift-examples/hello-world-macro/greeter'
+        path:
+          [
+            "./swift-examples/hello-world/greeter",
+            "./swift-examples/hello-world-macro/greeter",
+            "./swift-examples/hello-world-macro-multi-crate/greeter",
           ]
         target: [
-            'platform=macOS,arch=x86_64', 
-            'generic/platform=iOS',
+            "platform=macOS,arch=x86_64",
+            "generic/platform=iOS",
             # 'platform=iOS Simulator,os=latest'
           ]
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install
-      run: cargo install --force --path .
-    - name: Build example libraries
-      working-directory: ${{ matrix.path }}
-      run: cargo swift package --accept-all
-    - name: Build example apps
-      working-directory: ${{ matrix.path }}/../app
-      run: xcodebuild -scheme App -destination "${{ matrix.target }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+      - uses: actions/checkout@v4
+      - name: Install
+        run: cargo install --force --path .
+      - name: Build example libraries
+        working-directory: ${{ matrix.path }}
+        run: cargo swift package --accept-all
+      - name: Build example apps
+        working-directory: ${{ matrix.path }}/../app
+        run: xcodebuild -scheme App -destination "${{ matrix.target }}" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-swift"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -152,6 +152,7 @@ dependencies = [
  "convert_case",
  "dialoguer",
  "execute",
+ "glob",
  "indicatif",
  "itertools",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ camino = "1.1.6"
 cargo_metadata = "0.18.1"
 clap = { version = "4.5.4", features = ["derive"] }
 convert_case = "0.6.0"
+glob = "0.3.1"
 nonempty = "0.10.0"
 serde = { version = "1.0.197", features = ["derive"] }
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -29,19 +29,20 @@ pub fn generate_bindings(lib_path: &Utf8Path) -> Result<()> {
     )?;
 
     for output in uniffi_outputs {
-        let file_name = output.config.module_name();
+        let crate_name = output.crate_name;
         fs::copy(
-            out_dir.join(format!("{file_name}.swift")),
-            sources.join(format!("{file_name}.swift")),
+            out_dir.join(format!("{crate_name}.swift")),
+            sources.join(format!("{crate_name}.swift")),
         )?;
 
+        let ffi_name = format!("{crate_name}FFI");
         fs::copy(
-            out_dir.join(output.config.header_filename()),
-            headers.join(output.config.header_filename()),
+            out_dir.join(format!("{ffi_name}.h")),
+            headers.join(format!("{ffi_name}.h")),
         )?;
         fs::copy(
-            out_dir.join(output.config.modulemap_filename()),
-            headers.join(output.config.modulemap_filename()),
+            out_dir.join(format!("{ffi_name}.modulemap")),
+            headers.join(format!("{ffi_name}.modulemap")),
         )?;
     }
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -7,7 +7,7 @@ use uniffi_bindgen::bindings::swift::gen_swift::SwiftBindingGenerator;
 use crate::recreate_dir;
 
 /// Generates UniFFI bindings for crate and returns the .udl namespace
-pub fn generate_bindings(lib_path: &Utf8Path, crate_name: &str) -> Result<()> {
+pub fn generate_bindings(lib_path: &Utf8Path) -> Result<()> {
     let out_dir = Utf8Path::new("./generated");
     let headers = out_dir.join("headers");
     let sources = out_dir.join("sources");
@@ -16,26 +16,31 @@ pub fn generate_bindings(lib_path: &Utf8Path, crate_name: &str) -> Result<()> {
     create_dir(&headers)?;
     create_dir(&sources)?;
 
-    uniffi_bindgen::library_mode::generate_bindings(
+    let uniffi_outputs = uniffi_bindgen::library_mode::generate_bindings(
         lib_path,
-        Some(crate_name.to_owned()),
+        None,
         &SwiftBindingGenerator {},
         None,
         out_dir,
         false,
     )?;
 
-    fs::copy(
-        out_dir.join(format!("{crate_name}.swift")),
-        sources.join(format!("{crate_name}.swift")),
-    )?;
+    for output in uniffi_outputs {
+        let file_name = output.config.module_name();
+        fs::copy(
+            out_dir.join(format!("{file_name}.swift")),
+            sources.join(format!("{file_name}.swift")),
+        )?;
 
-    let header = format!("{crate_name}FFI.h");
-    fs::copy(out_dir.join(&header), headers.join(&header))?;
-    fs::copy(
-        out_dir.join(format!("{crate_name}FFI.modulemap")),
-        headers.join("module.modulemap"),
-    )?;
+        fs::copy(
+            out_dir.join(output.config.header_filename()),
+            headers.join(output.config.header_filename()),
+        )?;
+        fs::copy(
+            out_dir.join(output.config.modulemap_filename()),
+            headers.join(output.config.modulemap_filename()),
+        )?;
+    }
 
     Ok(())
 }

--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -164,7 +164,7 @@ fn run_for_crate(
 
     recreate_output_dir(&package_name).expect("Could not create package output directory!");
     create_xcframework_with_output(&targets, &crate_name, &package_name, mode, lib_type, config)?;
-    create_package_with_output(&package_name, &crate_name, disable_warnings, config)?;
+    create_package_with_output(&package_name, disable_warnings, config)?;
 
     Ok(())
 }
@@ -361,7 +361,7 @@ fn generate_bindings_with_output(
         let arch = archs.first();
         let lib_path: Utf8PathBuf = format!("{target}/{arch}/{mode}/{lib_file}").into();
 
-        generate_bindings(&lib_path, lib_name)
+        generate_bindings(&lib_path)
             .map_err(|e| format!("Could not generate UniFFI bindings for udl files due to the following error: \n {e}").into())
     })
 }
@@ -415,14 +415,13 @@ fn create_xcframework_with_output(
 
 fn create_package_with_output(
     package_name: &str,
-    namespace: &str,
     disable_warnings: bool,
     config: &Config,
 ) -> Result<()> {
     run_step(
         config,
         format!("Creating Swift Package '{package_name}'..."),
-        || create_swiftpackage(package_name, namespace, disable_warnings),
+        || create_swiftpackage(package_name, disable_warnings),
     )?;
 
     let spinner = config.silent.not().then(|| {

--- a/src/swiftpackage.rs
+++ b/src/swiftpackage.rs
@@ -1,4 +1,5 @@
 use askama::Template;
+use glob::glob;
 use std::fs::{copy, create_dir_all, write};
 
 use crate::{recreate_dir, templating, Result};
@@ -6,7 +7,7 @@ use crate::{recreate_dir, templating, Result};
 /// Create artifacts for a swift package given the package name
 ///
 /// **Note**: This method assumes that a directory with the package name and the .xcframework already exists
-pub fn create_swiftpackage(package_name: &str, namespace: &str, disable_warnings: bool) -> Result<()> {
+pub fn create_swiftpackage(package_name: &str, disable_warnings: bool) -> Result<()> {
     // TODO: Instead of assuming the directory and the xcframework, let this manage directory
     //  recreation and let it copy the xcframework
     let package_manifest = templating::PackageSwift {
@@ -23,14 +24,23 @@ pub fn create_swiftpackage(package_name: &str, namespace: &str, disable_warnings
     create_dir_all(format!("{}/Sources/{}", package_name, package_name))
         .map_err(|e| format!("Could not create module sources directory: \n {e}"))?;
 
-    copy(
-        format!("./generated/sources/{namespace}.swift"),
-        format!(
-            "{}/Sources/{}/{}.swift",
-            package_name, package_name, namespace
-        ),
-    )
-    .map_err(|e| format!("Could not copy generated swift source files: \n {e}"))?;
+    for swift_file in glob("./generated/sources/*.swift")
+        .map_err(|e| format!("Could not find generated swift source files: \n {e}"))?
+    {
+        let swift_file = swift_file
+            .map_err(|e| format!("Could not find generated swift source file: \n {e}"))?;
+        let file_name = swift_file
+            .file_name()
+            .ok_or("Could not get file name")?
+            .to_str()
+            .ok_or("Could not convert file name to string")?
+            .to_string();
+        copy(
+            swift_file,
+            format!("{}/Sources/{}/{}", package_name, package_name, file_name),
+        )
+        .map_err(|e| format!("Could not copy generated swift source files: \n {e}"))?;
+    }
 
     Ok(())
 }

--- a/swift-examples/hello-world-macro-multi-crate/app/.gitignore
+++ b/swift-examples/hello-world-macro-multi-crate/app/.gitignore
@@ -1,0 +1,3 @@
+**/xcuserdata/
+.DS_Store
+build/

--- a/swift-examples/hello-world-macro-multi-crate/app/HelloWorld.xcodeproj/project.pbxproj
+++ b/swift-examples/hello-world-macro-multi-crate/app/HelloWorld.xcodeproj/project.pbxproj
@@ -1,0 +1,385 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		40B2EC4C29DF56320028C4E8 /* HelloWorldApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B2EC4B29DF56320028C4E8 /* HelloWorldApp.swift */; };
+		40B2EC4E29DF56320028C4E8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B2EC4D29DF56320028C4E8 /* ContentView.swift */; };
+		40B2EC5029DF56340028C4E8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 40B2EC4F29DF56340028C4E8 /* Assets.xcassets */; };
+		40B2EC5429DF56340028C4E8 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 40B2EC5329DF56340028C4E8 /* Preview Assets.xcassets */; };
+		40B2EC5E29E08C0F0028C4E8 /* Greeter in Frameworks */ = {isa = PBXBuildFile; productRef = 40B2EC5D29E08C0F0028C4E8 /* Greeter */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		40B2EC4829DF56320028C4E8 /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		40B2EC4B29DF56320028C4E8 /* HelloWorldApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelloWorldApp.swift; sourceTree = "<group>"; };
+		40B2EC4D29DF56320028C4E8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		40B2EC4F29DF56340028C4E8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		40B2EC5129DF56340028C4E8 /* HelloWorld.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HelloWorld.entitlements; sourceTree = "<group>"; };
+		40B2EC5329DF56340028C4E8 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		40B2EC5B29E08B500028C4E8 /* Greeter */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Greeter; path = ../greeter/Greeter; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		40B2EC4529DF56320028C4E8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				40B2EC5E29E08C0F0028C4E8 /* Greeter in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		40B2EC3F29DF56320028C4E8 = {
+			isa = PBXGroup;
+			children = (
+				40B2EC5A29E08B4F0028C4E8 /* Packages */,
+				40B2EC4A29DF56320028C4E8 /* HelloWorld */,
+				40B2EC4929DF56320028C4E8 /* Products */,
+				40B2EC5C29E08C0F0028C4E8 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		40B2EC4929DF56320028C4E8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				40B2EC4829DF56320028C4E8 /* App.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		40B2EC4A29DF56320028C4E8 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				40B2EC4B29DF56320028C4E8 /* HelloWorldApp.swift */,
+				40B2EC4D29DF56320028C4E8 /* ContentView.swift */,
+				40B2EC4F29DF56340028C4E8 /* Assets.xcassets */,
+				40B2EC5129DF56340028C4E8 /* HelloWorld.entitlements */,
+				40B2EC5229DF56340028C4E8 /* Preview Content */,
+			);
+			path = HelloWorld;
+			sourceTree = "<group>";
+		};
+		40B2EC5229DF56340028C4E8 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				40B2EC5329DF56340028C4E8 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		40B2EC5A29E08B4F0028C4E8 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				40B2EC5B29E08B500028C4E8 /* Greeter */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		40B2EC5C29E08C0F0028C4E8 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		40B2EC4729DF56320028C4E8 /* App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 40B2EC5729DF56340028C4E8 /* Build configuration list for PBXNativeTarget "App" */;
+			buildPhases = (
+				40B2EC4429DF56320028C4E8 /* Sources */,
+				40B2EC4529DF56320028C4E8 /* Frameworks */,
+				40B2EC4629DF56320028C4E8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = App;
+			packageProductDependencies = (
+				40B2EC5D29E08C0F0028C4E8 /* Greeter */,
+			);
+			productName = HelloWorld;
+			productReference = 40B2EC4829DF56320028C4E8 /* App.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		40B2EC4029DF56320028C4E8 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1430;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					40B2EC4729DF56320028C4E8 = {
+						CreatedOnToolsVersion = 14.3;
+					};
+				};
+			};
+			buildConfigurationList = 40B2EC4329DF56320028C4E8 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 40B2EC3F29DF56320028C4E8;
+			productRefGroup = 40B2EC4929DF56320028C4E8 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				40B2EC4729DF56320028C4E8 /* App */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		40B2EC4629DF56320028C4E8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				40B2EC5429DF56340028C4E8 /* Preview Assets.xcassets in Resources */,
+				40B2EC5029DF56340028C4E8 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		40B2EC4429DF56320028C4E8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				40B2EC4E29DF56320028C4E8 /* ContentView.swift in Sources */,
+				40B2EC4C29DF56320028C4E8 /* HelloWorldApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		40B2EC5529DF56340028C4E8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		40B2EC5629DF56340028C4E8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+			};
+			name = Release;
+		};
+		40B2EC5829DF56340028C4E8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = HelloWorld/HelloWorld.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"HelloWorld/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.antonius.HelloWorld;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		40B2EC5929DF56340028C4E8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = HelloWorld/HelloWorld.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"HelloWorld/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
+				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
+				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.antonius.HelloWorld;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		40B2EC4329DF56320028C4E8 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				40B2EC5529DF56340028C4E8 /* Debug */,
+				40B2EC5629DF56340028C4E8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		40B2EC5729DF56340028C4E8 /* Build configuration list for PBXNativeTarget "App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				40B2EC5829DF56340028C4E8 /* Debug */,
+				40B2EC5929DF56340028C4E8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		40B2EC5D29E08C0F0028C4E8 /* Greeter */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Greeter;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 40B2EC4029DF56320028C4E8 /* Project object */;
+}

--- a/swift-examples/hello-world-macro-multi-crate/app/HelloWorld.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/swift-examples/hello-world-macro-multi-crate/app/HelloWorld.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/swift-examples/hello-world-macro-multi-crate/app/HelloWorld.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/swift-examples/hello-world-macro-multi-crate/app/HelloWorld.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,63 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/Assets.xcassets/Contents.json
+++ b/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/ContentView.swift
+++ b/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/ContentView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentView.swift
+//  HelloWorld
+//
+//  Created by Antonius Naumann on 06.04.23.
+//
+
+import SwiftUI
+import Greeter
+
+struct ContentView: View {
+    var body: some View {
+        Text(createGreeter().greet(name: "World"))
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/HelloWorld.entitlements
+++ b/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/HelloWorld.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/HelloWorldApp.swift
+++ b/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/HelloWorldApp.swift
@@ -1,0 +1,17 @@
+//
+//  HelloWorldApp.swift
+//  HelloWorld
+//
+//  Created by Antonius Naumann on 06.04.23.
+//
+
+import SwiftUI
+
+@main
+struct HelloWorldApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/swift-examples/hello-world-macro-multi-crate/app/HelloWorld/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-examples/hello-world-macro-multi-crate/greeter/.gitignore
+++ b/swift-examples/hello-world-macro-multi-crate/greeter/.gitignore
@@ -1,0 +1,4 @@
+/target
+/generated
+/Greeter/
+/Cargo.lock

--- a/swift-examples/hello-world-macro-multi-crate/greeter/Cargo.toml
+++ b/swift-examples/hello-world-macro-multi-crate/greeter/Cargo.toml
@@ -1,0 +1,16 @@
+workspace = { members = ["greeter-lib"] }
+
+[package]
+name = "greeter"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "staticlib", "lib"]
+name = "greeter"
+
+[dependencies]
+uniffi = "0.27"
+greeter-lib = { path = "./greeter-lib" }

--- a/swift-examples/hello-world-macro-multi-crate/greeter/greeter-lib/Cargo.toml
+++ b/swift-examples/hello-world-macro-multi-crate/greeter/greeter-lib/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "greeter-lib"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+uniffi = "0.27"

--- a/swift-examples/hello-world-macro-multi-crate/greeter/greeter-lib/src/lib.rs
+++ b/swift-examples/hello-world-macro-multi-crate/greeter/greeter-lib/src/lib.rs
@@ -1,0 +1,11 @@
+uniffi::setup_scaffolding!();
+
+#[derive(uniffi::Object)]
+pub struct Greeter {}
+
+#[uniffi::export]
+impl Greeter {
+    pub fn greet(&self, name: String) -> String {
+        format!("Hello, {}!", name)
+    }
+}

--- a/swift-examples/hello-world-macro-multi-crate/greeter/src/lib.rs
+++ b/swift-examples/hello-world-macro-multi-crate/greeter/src/lib.rs
@@ -1,0 +1,8 @@
+use greeter_lib::Greeter;
+
+uniffi::setup_scaffolding!();
+
+#[uniffi::export]
+pub fn create_greeter() -> Greeter {
+    Greeter {}
+}


### PR DESCRIPTION
In workspaces where UniFFI types are declared in multiple separate crates, UniFFI bindgen generates a set of Swift files, headers and a header map for each Rust crate that declares UniFFI types.
Currently, only the files corresponding to the main crate (from where `cargo swift` was called) are added. This PR copies all the files to the resulting xcode project.