### PR TITLE
Make xcframework name configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-swift"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,9 @@ enum Action {
         #[arg(short = 'n', long = "name")]
         package_name: Option<String>,
 
+        #[arg(long, default_value = "RustFramework")]
+        xcframework_name: String,
+
         #[arg(short, long)]
         /// Build package optimized for release (default: debug)
         release: bool,
@@ -120,6 +123,7 @@ fn main() -> ExitCode {
         Action::Package {
             platforms,
             package_name,
+            xcframework_name,
             suppress_warnings,
             release,
             lib_type,
@@ -130,6 +134,7 @@ fn main() -> ExitCode {
         } => package::run(
             platforms,
             package_name,
+            xcframework_name,
             suppress_warnings,
             config,
             if release { Mode::Release } else { Mode::Debug },

--- a/src/swiftpackage.rs
+++ b/src/swiftpackage.rs
@@ -7,11 +7,16 @@ use crate::{recreate_dir, templating, Result};
 /// Create artifacts for a swift package given the package name
 ///
 /// **Note**: This method assumes that a directory with the package name and the .xcframework already exists
-pub fn create_swiftpackage(package_name: &str, disable_warnings: bool) -> Result<()> {
+pub fn create_swiftpackage(
+    package_name: &str,
+    xcframework_name: &str,
+    disable_warnings: bool,
+) -> Result<()> {
     // TODO: Instead of assuming the directory and the xcframework, let this manage directory
     //  recreation and let it copy the xcframework
     let package_manifest = templating::PackageSwift {
         package_name,
+        xcframework_name,
         disable_warnings,
     };
 

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -32,5 +32,6 @@ pub(crate) struct LibUdl<'a> {
 #[template(path = "Package.swift", escape = "none")]
 pub(crate) struct PackageSwift<'a> {
     pub(crate) package_name: &'a str,
+    pub(crate) xcframework_name: &'a str,
     pub(crate) disable_warnings: bool,
 }

--- a/src/xcframework.rs
+++ b/src/xcframework.rs
@@ -9,6 +9,7 @@ use crate::{Mode, Result, Target};
 pub fn create_xcframework(
     targets: &[Target],
     lib_name: &str,
+    xcframework_name: &str,
     generated_dir: &Path,
     output_dir: &Path,
     mode: Mode,
@@ -28,9 +29,7 @@ pub fn create_xcframework(
         .to_str()
         .ok_or(anyhow!("Output directory has an invalid name!"))?;
 
-    // TODO: this should be given as an argument instead of being hardcoded
-    //  because it needs to match the name given in swift package manifest
-    let framework = format!("{output_dir_name}/RustFramework.xcframework");
+    let framework = format!("{output_dir_name}/{xcframework_name}.xcframework");
 
     let mut xcodebuild = Command::new("xcodebuild");
     xcodebuild.arg("-create-xcframework");

--- a/templates/Package.swift
+++ b/templates/Package.swift
@@ -18,11 +18,11 @@ let package = Package(
     ],
     dependencies: [ ],
     targets: [
-        .binaryTarget(name: "RustFramework", path: "./RustFramework.xcframework"),
+        .binaryTarget(name: "{{ xcframework_name }}", path: "./{{ xcframework_name }}.xcframework"),
         .target(
             name: "{{ package_name }}",
             dependencies: [
-                .target(name: "RustFramework")
+                .target(name: "{{ xcframework_name }}")
             ]{% if disable_warnings %},
             swiftSettings: [
                 .unsafeFlags(["-suppress-warnings"]),


### PR DESCRIPTION
I added a CLI flag like the TODO suggested. It could have been a simple matter of concatenating `package_name` with `RustFramework` but this way isn't a breaking change.

A couple of other things:
- I haven't added a test but now there's only two mentions of `RustFramework` (in a test and as the default value) so I'm assuming it's tested properly already.
- Clippy has a warning which I believe was introduced in a recent version of Rust. I can remove the trait function in this PR if you'd like.