### PR TITLE
Add target setting that enables building single architecture only

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,10 @@ enum Action {
         #[arg(short, long, trailing_var_arg = true, num_args = 1..=4, ignore_case = true)]
         platforms: Option<Vec<package::Platform>>,
 
+        #[arg(long)]
+        /// Build package for the specified target triplet only.
+        target: Option<String>,
+
         #[arg(short = 'n', long = "name")]
         package_name: Option<String>,
 
@@ -122,6 +126,7 @@ fn main() -> ExitCode {
 
         Action::Package {
             platforms,
+            target,
             package_name,
             xcframework_name,
             suppress_warnings,
@@ -133,6 +138,7 @@ fn main() -> ExitCode {
             no_default_features,
         } => package::run(
             platforms,
+            target.as_deref(),
             package_name,
             xcframework_name,
             suppress_warnings,

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -51,7 +51,11 @@ impl Target {
             .into_iter()
             .map(|arch| {
                 // FIXME: Remove nightly for Tier 3 targets here once build-std is stabilized
-                let mut cmd = if self.platform().is_tier_3() { command("cargo +nightly build -Z build-std") } else { command("cargo build") };
+                let mut cmd = if self.platform().is_tier_3() {
+                    command("cargo +nightly build -Z build-std")
+                } else {
+                    command("cargo build")
+                };
                 cmd.arg("--target").arg(arch);
 
                 match mode {


### PR DESCRIPTION
This PR adds ability to scope package builds to individual target triplet using an optional `--target <target-triplet>` CLI setting. The CLI tool will error if the specified target does not match any of the architectures in the returned list of targets. When omitted, the build proceeds as normal by building all targets in succession.

As described in the linked issue, I believe this addition could help to cut build times during development and achieve a similar behaviour as `ONLY_ACTIVE_ARCH` flag in Xcode build configuration when integrating build process using external build system.

Fixes #62