### PR TITLE
fix: Made plugin work with namespaces differing from crate name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-swift"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "askama",

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -35,13 +35,13 @@ pub fn generate_bindings(lib_path: &Utf8Path) -> Result<()> {
         .open(headers.join("module.modulemap"))?;
 
     for output in uniffi_outputs {
-        let crate_name = output.ci.crate_name();
+        let namespace = output.ci.namespace();
         fs::copy(
-            out_dir.join(format!("{crate_name}.swift")),
-            sources.join(format!("{crate_name}.swift")),
+            out_dir.join(format!("{namespace}.swift")),
+            sources.join(format!("{namespace}.swift")),
         )?;
 
-        let ffi_name = format!("{crate_name}FFI");
+        let ffi_name = format!("{namespace}FFI");
         fs::copy(
             out_dir.join(format!("{ffi_name}.h")),
             headers.join(format!("{ffi_name}.h")),


### PR DESCRIPTION
Fixes this: https://github.com/antoniusnaumann/cargo-swift/issues/69

So the actual problem here is that when the crate name and the namespace name in the udl file differ cargo swift thinks the generated files are named like the crate, but they are actually named like the namespace.

For example cratename `yes_you_like` with namespace `yesYouLike` results in `generated/yesYouLike.swift` but cargo swift looks for `generated/yes_you_like.swift` 