### PR TITLE
add flag to change the swift-tools-version

### DIFF
--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -68,6 +68,7 @@ pub fn run(
     lib_type_arg: LibTypeArg,
     features: FeatureOptions,
     skip_toolchains_check: bool,
+    swift_tools_version: &str,
 ) -> Result<()> {
     // TODO: Allow path as optional argument to take other directories than current directory
     // let crates = metadata().uniffi_crates();
@@ -88,6 +89,7 @@ pub fn run(
             lib_type_arg,
             features,
             skip_toolchains_check,
+            swift_tools_version,
         );
     } else if package_name.is_some() {
         Err("Package name can only be specified when building a single crate!")?;
@@ -109,6 +111,7 @@ pub fn run(
                 lib_type_arg.clone(),
                 features.clone(),
                 skip_toolchains_check,
+                swift_tools_version,
             )
         })
         .filter_map(|result| result.err())
@@ -129,6 +132,7 @@ fn run_for_crate(
     lib_type_arg: LibTypeArg,
     features: FeatureOptions,
     skip_toolchains_check: bool,
+    swift_tools_version: &str,
 ) -> Result<()> {
     let lib = current_crate
         .targets
@@ -234,6 +238,7 @@ fn run_for_crate(
         &xcframework_name,
         disable_warnings,
         &platforms,
+        swift_tools_version,
         config,
     )?;
 
@@ -667,12 +672,21 @@ fn create_package_with_output(
     xcframework_name: &str,
     disable_warnings: bool,
     platforms: &[PlatformSpec],
+    swift_tools_version: &str,
     config: &Config,
 ) -> Result<()> {
     run_step(
         config,
         format!("Creating Swift Package '{package_name}'..."),
-        || create_swiftpackage(package_name, xcframework_name, disable_warnings, platforms),
+        || {
+            create_swiftpackage(
+                package_name,
+                xcframework_name,
+                disable_warnings,
+                platforms,
+                swift_tools_version,
+            )
+        },
     )?;
 
     let spinner = config.silent.not().then(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,9 @@ enum Action {
 
         #[arg(long)]
         no_default_features: bool,
+
+        #[arg(long, default_value = "5.5")]
+        swift_tools_version: String,
     },
 }
 
@@ -145,6 +148,7 @@ fn main() -> ExitCode {
             features,
             all_features,
             no_default_features,
+            swift_tools_version,
         } => package::run(
             platforms,
             target.as_deref(),
@@ -160,6 +164,7 @@ fn main() -> ExitCode {
                 no_default_features,
             },
             skip_toolchains_check,
+            &swift_tools_version,
         ),
     };
 

--- a/src/swiftpackage.rs
+++ b/src/swiftpackage.rs
@@ -13,6 +13,7 @@ pub fn create_swiftpackage(
     xcframework_name: &str,
     disable_warnings: bool,
     platforms: &[package::PlatformSpec],
+    swift_tools_version: &str,
 ) -> Result<()> {
     let platforms = &platforms.iter().map(|p| p.package_swift()).join(", ");
     // TODO: Instead of assuming the directory and the xcframework, let this manage directory
@@ -22,6 +23,7 @@ pub fn create_swiftpackage(
         xcframework_name,
         disable_warnings,
         platforms,
+        swift_tools_version,
     };
 
     write(

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -35,4 +35,5 @@ pub(crate) struct PackageSwift<'a> {
     pub(crate) xcframework_name: &'a str,
     pub(crate) disable_warnings: bool,
     pub(crate) platforms: &'a str,
+    pub(crate) swift_tools_version: &'a str,
 }

--- a/templates/Package.swift
+++ b/templates/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:{{ swift_tools_version }}
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 // Swift Package: {{ package_name }}
 


### PR DESCRIPTION
defaults to the previously hardcoded `5.5`

this is required in order to specify minimum iOS versions > 16 or macOS > 12 in `Package.swift` (see #89)

related to #88 and #89; I therefore based this PR on #89