### PR TITLE
Update uniffi to 0.31.1, bump cargo-swift to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,9 +884,9 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed0150801958d4825da56a41c71f000a457ac3a4613fa9647df78ac4b6b6881"
+checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
 dependencies = [
  "anyhow",
  "askama 0.14.0",
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
+checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df6d413db2827c68588f8149d30d49b71d540d46539e435b23a7f7dbd4d4f86"
+checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
+checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
 dependencies = [
  "anyhow",
  "heck",
@@ -948,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1a7339539bf6f6fa3e9b534dece13f778bda2d54b1a6d4e40b4d6090ac26e7"
+checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
 dependencies = [
  "anyhow",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ execute = "0.2.13"
 indicatif = "0.18.3"
 
 # FFI Bindings
-uniffi_bindgen = { version = "=0.31.0" }
+uniffi_bindgen = { version = "=0.31.1" }
 
 # Error Handling
 anyhow = "1.0.98"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Currently, `cargo swift` does not detect the UniFFI version of your project auto
 | 0.29   | 0.9         |
 | 0.30   | 0.10        |
 | 0.31   | 0.11        |
+| 0.31.1 | 0.11.1      |
 
 To do so, run 
 ```


### PR DESCRIPTION
Uniffi 0.31.1 comes with a lot of bug fixes for Swift.

https://github.com/mozilla/uniffi-rs/compare/v0.31.0...v0.31.1