### PR TITLE
fix: support multi-crate (multi-component) frameworks

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,6 +1,5 @@
 use std::{
     fs::{self, create_dir},
-    io::{self, Write},
 };
 
 use anyhow::anyhow;
@@ -10,12 +9,20 @@ use uniffi_bindgen::bindings::{GenerateOptions, TargetLanguage};
 
 use crate::recreate_dir;
 
-/// Generates UniFFI bindings for crate and returns the FFI module name.
+/// Generates UniFFI bindings for the crate and returns the primary FFI module name.
 ///
-/// This function respects the `ffi_module_name` and `ffi_module_filename` settings
-/// in uniffi.toml. The returned FFI module name is detected from the generated
-/// header files, which reflect whatever is configured in uniffi.toml.
-pub fn generate_bindings(lib_path: &Utf8Path) -> Result<String> {
+/// A library may comprise several UniFFI components — multiple crates that each call
+/// `setup_scaffolding!()` — in which case `uniffi-bindgen --library` emits one FFI header,
+/// `module.modulemap`, and Swift file per component. When packaged as a dynamic `.framework`, a
+/// bundle only exposes the Clang module whose name matches the bundle, so several `framework
+/// module` blocks in one bundle would leave all but one unimportable. To keep every component
+/// importable, a single module is emitted that exposes all component headers (UniFFI's
+/// `UNIFFI_SHARED_H` / `UNIFFI_FFIDEF_*` include guards deduplicate the shared runtime types) and
+/// each generated Swift file's FFI import is repointed at it.
+///
+/// `lib_name` identifies the primary component, whose FFI module name the framework and
+/// xcframework take, so the result does not depend on directory iteration order.
+pub fn generate_bindings(lib_path: &Utf8Path, lib_name: &str) -> Result<String> {
     let out_dir = Utf8Path::new("./generated");
     let headers = out_dir.join("headers");
     let sources = out_dir.join("sources");
@@ -33,57 +40,78 @@ pub fn generate_bindings(lib_path: &Utf8Path) -> Result<String> {
     };
     uniffi_bindgen::bindings::generate(options)?;
 
-    let mut modulemap = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(headers.join("module.modulemap"))?;
-
-    // Detect the FFI module name from the generated header file.
-    // This respects ffi_module_name/ffi_module_filename from uniffi.toml.
-    let ffi_module_name = fs::read_dir(out_dir)?
+    // Collect the FFI module name of every generated component (one per `*.h`, excluding the
+    // Swift bridging header).
+    let mut ffi_modules: Vec<String> = fs::read_dir(out_dir)?
         .filter_map(|entry| entry.ok())
-        .find(|entry| {
-            entry.path().extension().is_some_and(|ext| ext == "h")
-                && entry
-                    .path()
-                    .file_stem()
-                    .is_some_and(|stem| !stem.to_string_lossy().contains("BridgingHeader"))
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "h"))
+        .filter_map(|path| {
+            path.file_stem()
+                .map(|stem| stem.to_string_lossy().to_string())
+                .filter(|stem| !stem.contains("BridgingHeader"))
         })
-        .ok_or_else(|| anyhow!("Could not find generated header file in {}", out_dir))?
-        .path()
-        .file_stem()
-        .unwrap()
-        .to_string_lossy()
-        .to_string();
+        .collect();
+    ffi_modules.sort();
+    ffi_modules.dedup();
 
-    let dir = fs::read_dir(out_dir)?;
+    if ffi_modules.is_empty() {
+        return Err(anyhow!("Could not find generated header file in {}", out_dir).into());
+    }
 
-    for f in dir {
-        let f = f?;
-        let file_path = f.path();
+    // The primary FFI module is the one imported by the built crate's own Swift file
+    // (`{lib_name}.swift`). Falling back to the first header keeps single-component behaviour.
+    let primary = primary_ffi_module(out_dir, lib_name, &ffi_modules)
+        .unwrap_or_else(|| ffi_modules[0].clone());
 
-        if !f.metadata()?.is_file() {
+    // Emit one module exposing every component header (see doc comment).
+    let mut modulemap = format!("module {primary} {{\n");
+    for module in &ffi_modules {
+        modulemap.push_str(&format!("    header \"{module}.h\"\n"));
+    }
+    modulemap.push_str("    export *\n    use \"Darwin\"\n    use \"_Builtin_stdbool\"\n    use \"_Builtin_stdint\"\n}\n");
+    fs::write(headers.join("module.modulemap"), modulemap)?;
+
+    // Copy headers and Swift sources into the package layout, repointing every component's FFI
+    // import at the single merged module. Per-component `.modulemap` files are ignored — we
+    // wrote the merged one above.
+    for entry in fs::read_dir(out_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if !entry.metadata()?.is_file() {
             continue;
         }
+        let Some(name) = path.file_name() else { continue };
+        let Some(ext) = path.extension() else { continue };
 
-        let Some(name) = file_path.file_name() else {
-            continue;
-        };
-
-        let Some(ext) = file_path.extension() else {
-            continue;
-        };
-
-        if ext == "swift" {
-            fs::copy(out_dir.join_os(name), sources.join_os(name))?;
-        } else if ext == "h" {
-            fs::copy(out_dir.join_os(name), headers.join_os(name))?;
-        } else if ext == "modulemap" {
-            let mut modulemap_part = fs::OpenOptions::new().read(true).open(file_path)?;
-            io::copy(&mut modulemap_part, &mut modulemap)?;
-            modulemap.write_all(b"\n")?;
+        if ext == "h" {
+            fs::copy(&path, headers.join_os(name))?;
+        } else if ext == "swift" {
+            let mut content = fs::read_to_string(&path)?;
+            for module in &ffi_modules {
+                if module == &primary {
+                    continue;
+                }
+                content = content
+                    .replace(&format!("canImport({module})"), &format!("canImport({primary})"))
+                    .replace(&format!("import {module}\n"), &format!("import {primary}\n"));
+            }
+            fs::write(sources.join_os(name), content)?;
         }
     }
 
-    Ok(ffi_module_name)
+    Ok(primary)
+}
+
+/// Detects the FFI module imported by the built crate's own Swift bindings file.
+///
+/// UniFFI names that file after the crate's namespace, which defaults to the library name.
+/// Returns the imported module only if it is one of the generated FFI modules.
+fn primary_ffi_module(out_dir: &Utf8Path, lib_name: &str, ffi_modules: &[String]) -> Option<String> {
+    let content = fs::read_to_string(out_dir.join(format!("{lib_name}.swift"))).ok()?;
+    content.lines().find_map(|line| {
+        let module = line.trim().strip_prefix("import ")?.trim();
+        ffi_modules.iter().find(|m| m.as_str() == module).cloned()
+    })
 }

--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -758,7 +758,7 @@ fn generate_bindings_with_output(
         let arch = archs.first();
         let lib_path: Utf8PathBuf = format!("{target}/{arch}/{mode}/{lib_file}").into();
 
-        generate_bindings(&lib_path)
+        generate_bindings(&lib_path, lib_name)
             .map_err(|e| format!("Could not generate UniFFI bindings for udl files due to the following error: \n {e}").into())
     })
 }

--- a/testing/end-to-end/package-dynamic.swift
+++ b/testing/end-to-end/package-dynamic.swift
@@ -38,7 +38,41 @@ cargoToml = cargoToml.replacingOccurrences(
     of: "crate-type = [\"staticlib\", \"lib\"]",
     with: "crate-type = [\"cdylib\", \"lib\"]"
 )
+// Make this a multi-crate (multi-component) build: add a second UniFFI crate as a path
+// dependency + workspace member. This exercises the framework-module-per-component path.
+cargoToml = cargoToml.replacingOccurrences(
+    of: "[dependencies]\n",
+    with: "[dependencies]\ndep_crate = { path = \"dep_crate\" }\n"
+)
+cargoToml += "\n[workspace]\nmembers = [\"dep_crate\"]\n"
 try! cargoToml.write(toFile: cargoTomlPath, atomically: true, encoding: .utf8)
+
+// Second component: its own crate with setup_scaffolding!() (a separate UniFFI namespace).
+print("Adding second crate (dep_crate)...")
+try! FileManager.default.createDirectory(
+    atPath: "\(projectName)/dep_crate/src", withIntermediateDirectories: true
+)
+try! """
+[package]
+name = "dep_crate"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+uniffi = "0.31"
+""".write(toFile: "\(projectName)/dep_crate/Cargo.toml", atomically: true, encoding: .utf8)
+try! """
+uniffi::setup_scaffolding!();
+
+#[uniffi::export]
+pub fn dep_hello() -> String { "dep".to_string() }
+""".write(toFile: "\(projectName)/dep_crate/src/lib.rs", atomically: true, encoding: .utf8)
+
+// Reference dep_crate from the main crate so its component is linked into the cdylib.
+let mainLibPath = "\(projectName)/src/lib.rs"
+var mainLib = try! String(contentsOfFile: mainLibPath, encoding: .utf8)
+mainLib += "\n#[uniffi::export]\npub fn dep_passthrough() -> String { dep_crate::dep_hello() }\n"
+try! mainLib.write(toFile: mainLibPath, atomically: true, encoding: .utf8)
 
 // Add uniffi.toml with custom ffi_module_name
 print("Adding uniffi.toml with custom ffi_module_name...")
@@ -277,6 +311,50 @@ for subframework in subframeworks {
     }
     print("  \(subframework): install name OK")
 }
+
+// --- Multi-crate regression checks (#97/#99/#100) ---
+// The bundle must expose exactly one framework module (named after the bundle), not one per
+// component, and every generated Swift file must import that single module.
+print("Checking merged framework module...")
+for subframework in subframeworks {
+    let frameworkPath = "\(xcframeworkPath)/\(subframework)/\(xcFrameworkName).framework"
+    let shallow = "\(frameworkPath)/Modules/module.modulemap"
+    let versioned = "\(frameworkPath)/Versions/A/Modules/module.modulemap"
+    let mmPath = fileExists(atPath: shallow) ? shallow : versioned
+    let mm = (try? String(contentsOfFile: mmPath, encoding: .utf8)) ?? ""
+    let moduleCount = mm.components(separatedBy: "framework module ").count - 1
+    guard moduleCount == 1 else {
+        error("\(subframework): expected exactly 1 framework module, found \(moduleCount)\n\(mm)")
+        exit(1)
+    }
+}
+
+// There must be >=2 component Swift files (multi-crate), all importing the single module.
+let sourcesDir = "\(projectName)/\(packageName)/Sources/\(packageName)"
+let swiftFiles = try! FileManager.default.contentsOfDirectory(atPath: sourcesDir)
+    .filter { $0.hasSuffix(".swift") }
+guard swiftFiles.count >= 2 else {
+    error("Expected >=2 component Swift files (multi-crate), found \(swiftFiles)")
+    exit(1)
+}
+
+// Type-check the generated sources the way Xcode resolves framework modules: by bundle name,
+// via -F. `swift build` loads the modulemap directly and does not surface this, so -F
+// resolution is what guards it. (#97/#99)
+print("Type-checking generated sources with -F (Xcode-style framework resolution)...")
+let macosSlice = subframeworks.first { $0.hasPrefix("macos") }!
+let swiftc = Process()
+swiftc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+swiftc.arguments = ["swiftc", "-typecheck", "-module-name", packageName,
+                    "-F", "\(xcframeworkPath)/\(macosSlice)"]
+    + swiftFiles.map { "\(sourcesDir)/\($0)" }
+try! swiftc.run()
+swiftc.waitUntilExit()
+guard swiftc.terminationStatus == 0 else {
+    error("swiftc -F failed: generated sources do not resolve under Xcode-style framework module resolution")
+    exit(1)
+}
+print("  -F resolution OK")
 
 // Build the Swift package to verify it links correctly
 print("Building Swift package...")


### PR DESCRIPTION
## Summary

`cargo swift package` breaks when the built library comprises **more than one UniFFI
component** (multiple crates that each call `setup_scaffolding!()`). `uniffi-bindgen
--library` emits one FFI header, `module.modulemap`, and Swift file per component, but the
dynamic-framework packaging only handles the single-component case, producing a framework
that won't compile or import.

This PR makes the dynamic `.framework` path multi-component aware:

- **One Clang module exposing every component header.** A dynamic `.framework` only exposes
  the module whose name matches the bundle, so several `framework module` blocks in one
  bundle leave all but one unimportable. Instead a single module lists all component headers
  (UniFFI's `UNIFFI_SHARED_H` / `UNIFFI_FFIDEF_*` include guards deduplicate the shared
  runtime types), and each generated Swift file's FFI import is repointed at it.
- **Deterministic framework name.** The primary component is derived from the target crate's
  own generated Swift file rather than from directory iteration order, so the
  framework/xcframework no longer take the name of an arbitrary dependency crate.

## Resolves

- #97 — multi-crate example fails with `Unable to resolve module dependency: '<crate>FFI'`
- #99 — dynamic-library bundling broken since 1.11.1 for a dylib linking two crates
- #100 — invalid framework name when `ffi_module_name` is unset (taken from the first
  dependent crate instead of the target crate)

## Testing

Extended `testing/end-to-end/package-dynamic.swift` with a second crate so the fixture
exercises the multi-component path, plus regression checks: exactly one `framework module`,
at least two component Swift files, and a `swiftc -typecheck -F <slice>` compile against the
built framework. The `-F` check matters because Xcode resolves framework modules by bundle
name and catches the breakage that `swift build` — which loads the modulemap directly — does
not.
