### PR TITLE
Update uniffi to 0.31.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,9 +884,9 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
+checksum = "c4a0c9b375d32e1365cdb2bdd7cb495eecf6fac851ddbad077412b4ee1888514"
 dependencies = [
  "anyhow",
  "askama 0.14.0",
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
+checksum = "4641669b48fefbc5e80ff08c5004d9c7617fb91232131a6734ab6712779cb04c"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
+checksum = "58d5b94fc92803d21b2928bd15c6f06e57609b95caf98ea561c99cda1b6d2a25"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
+checksum = "032739b3ec725576914c15899dedaf080163ced86b6934566c20ec2b20ce90ca"
 dependencies = [
  "anyhow",
  "heck",
@@ -948,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
+checksum = "fc0a1d0a0252ce1af9e8ce78ba67ac0d8937fb2bedaf10cbddd43d3614d06ec6"
 dependencies = [
  "anyhow",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ execute = "0.2.13"
 indicatif = "0.18.3"
 
 # FFI Bindings
-uniffi_bindgen = { version = "=0.31.1" }
+uniffi_bindgen = { version = "=0.31.2" }
 
 # Error Handling
 anyhow = "1.0.98"


### PR DESCRIPTION
Bumps `uniffi_bindgen` from `0.31.1` to `0.31.2`.

The notable change for the Swift backend is
[mozilla/uniffi-rs#2886](https://github.com/mozilla/uniffi-rs/pull/2886)
(*swift: nonisolated(unsafe) on callback vtablePtr*), shipped in
[uniffi 0.31.2](https://github.com/mozilla/uniffi-rs/blob/v0.31.2/CHANGELOG.md)
as "Prevent strict concurrency warning with callback interface tables".

Under the Swift 6 language mode a non-isolated `static let` of a non-`Sendable` type is
rejected, so the callback-interface `vtablePtr` emitted by 0.31.1 only compiles in Swift 5
mode. With 0.31.2 it is generated as `nonisolated(unsafe)`, so packages with callback
interfaces build cleanly under the Swift 6 language mode without falling back to
`swiftLanguageModes: [.v5]`.
