### PR TITLE
feat(xcframework): embed .dSYM bundles via --debug-symbols

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, macos-14]
-        test: [init, package, package-dynamic, exclude-arch]
+        test: [init, package, package-dynamic, exclude-arch, debug-symbols]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -72,6 +72,7 @@ pub fn run(
     privacy_manifest: Option<PathBuf>,
     bundle_identifier: Option<String>,
     exclude_arch: Vec<String>,
+    debug_symbols: bool,
 ) -> Result<()> {
     // Show deprecation warning if --xcframework-name is used
     if xcframework_name.is_some() {
@@ -105,6 +106,7 @@ pub fn run(
             privacy_manifest.as_deref(),
             bundle_identifier,
             &exclude_arch,
+            debug_symbols,
         );
     } else if package_name.is_some() {
         Err("Package name can only be specified when building a single crate!")?;
@@ -130,6 +132,7 @@ pub fn run(
                 privacy_manifest.as_deref(),
                 bundle_identifier.clone(),
                 &exclude_arch,
+                debug_symbols,
             )
         })
         .filter_map(|result| result.err())
@@ -154,6 +157,7 @@ fn run_for_crate(
     privacy_manifest: Option<&Path>,
     bundle_identifier: Option<String>,
     exclude_arch: &[String],
+    debug_symbols: bool,
 ) -> Result<()> {
     let lib = current_crate
         .targets
@@ -325,6 +329,7 @@ fn run_for_crate(
         config,
         privacy_manifest,
         bundle_identifier.as_deref(),
+        debug_symbols,
     )?;
     create_package_with_output(
         &package_name,
@@ -798,6 +803,7 @@ fn create_xcframework_with_output(
     config: &Config,
     privacy_manifest: Option<&Path>,
     bundle_identifier: Option<&str>,
+    debug_symbols: bool,
 ) -> Result<()> {
     run_step(config, "Creating XCFramework...", || {
         // TODO: show command spinner here with xcbuild command
@@ -816,6 +822,7 @@ fn create_xcframework_with_output(
             lib_type,
             privacy_manifest,
             bundle_identifier,
+            debug_symbols,
         )
     })
     .map_err(|e| format!("Failed to create XCFramework due to the following error: \n {e}").into())

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,19 @@ enum Action {
         /// Universal slices with one remaining arch collapse to a single-arch
         /// slice; slices with no remaining archs drop out entirely.
         exclude_arch: Vec<String>,
+
+        #[arg(long = "debug-symbols")]
+        /// Embed .dSYM debug-symbol bundles in the xcframework so Xcode and
+        /// crash-symbolication tools can resolve Rust stack frames at runtime.
+        /// Requires Cargo profile flags that produce dSYMs — typically:
+        ///     [profile.release]
+        ///     debug = "limited"
+        ///     split-debuginfo = "packed"
+        /// (cargo runs dsymutil at link time, writing
+        /// target/<arch>/<mode>/deps/lib<name>.dylib.dSYM). cargo-swift then
+        /// lipo's the per-arch DWARF binaries to match each xcframework slice
+        /// and passes them to `xcodebuild -create-xcframework -debug-symbols`.
+        debug_symbols: bool,
     },
 }
 
@@ -177,6 +190,7 @@ fn main() -> ExitCode {
             privacy_manifest,
             bundle_identifier,
             exclude_arch,
+            debug_symbols,
         } => package::run(
             platforms,
             target.as_deref(),
@@ -196,6 +210,7 @@ fn main() -> ExitCode {
             privacy_manifest,
             bundle_identifier,
             exclude_arch,
+            debug_symbols,
         ),
     };
 

--- a/src/xcframework.rs
+++ b/src/xcframework.rs
@@ -399,6 +399,31 @@ fn prepare_target_dsym(
         })?;
     }
 
+    // Rewrite CFBundleIdentifier so the dSYM Info.plist reports the framework
+    // identifier (com.apple.xcode.dsym.<framework>.framework) instead of the
+    // value cargo's dsymutil inherited from the raw .dylib build artifact
+    // (com.apple.xcode.dsym.lib<crate>.dylib). Symbolication keys on Mach-O
+    // UUIDs, so this is cosmetic — but it's what Apple's tooling emits for
+    // archive-built frameworks and what crash-reporter vendors expect.
+    let info_plist = staged.join("Contents/Info.plist");
+    if info_plist.exists() {
+        let bundle_id = format!("com.apple.xcode.dsym.{framework_name}.framework");
+        let status = Command::new("plutil")
+            .args(["-replace", "CFBundleIdentifier", "-string"])
+            .arg(&bundle_id)
+            .arg(&info_plist)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .status()
+            .context("Failed to run plutil on dSYM Info.plist")?;
+        if !status.success() {
+            return Err(anyhow!(
+                "plutil failed rewriting CFBundleIdentifier in {info_plist:?}"
+            )
+            .into());
+        }
+    }
+
     if per_arch_dsyms.len() > 1 {
         let mut lipo = Command::new("lipo");
         for d in &per_arch_dsyms {

--- a/src/xcframework.rs
+++ b/src/xcframework.rs
@@ -1,6 +1,7 @@
 use crate::console::Error;
 use crate::lib_type::LibType;
-use crate::targets::ApplePlatform;
+use crate::metadata::{metadata, MetadataExt};
+use crate::targets::{library_file_name, ApplePlatform};
 use crate::{Mode, Result, Target};
 use anyhow::{anyhow, Context};
 use std::fs::{self, remove_dir_all, DirEntry};
@@ -304,6 +305,149 @@ fn create_versioned_symlinks(framework_dir: &Path, framework_name: &str) -> Resu
     Ok(())
 }
 
+/// Per-arch dSYM location produced by Cargo when `[profile.<mode>]` has
+/// `debug = "limited"` (or higher) + `split-debuginfo = "packed"` on macOS:
+/// Cargo invokes dsymutil during the link, dropping a bundle next to the dylib.
+fn arch_dsym_path(arch: &str, lib_name: &str, mode: Mode) -> PathBuf {
+    let target_dir = metadata().target_dir();
+    let mode_dir = match mode {
+        Mode::Debug => "debug",
+        Mode::Release => "release",
+    };
+    let dsym_name = format!("{}.dSYM", library_file_name(lib_name, LibType::Dynamic));
+    PathBuf::from(format!("{target_dir}/{arch}/{mode_dir}/deps/{dsym_name}"))
+}
+
+/// Materialise a dSYM bundle that matches a Target's framework binary:
+/// - Single-arch targets: copy the per-arch dSYM with its DWARF Mach-O renamed
+///   to `<framework_name>`.
+/// - Universal targets: `lipo -create` the per-arch DWARF Mach-Os into a fat
+///   binary at the renamed location. The result's embedded UUIDs cover every
+///   arch in the corresponding framework binary, so Xcode auto-loads symbols
+///   regardless of which slice the consumer is running.
+///
+/// Returns the staged dSYM path, ready to pass to
+/// `xcodebuild -create-xcframework -debug-symbols`. The staged bundle is named
+/// `<framework_name>.framework.dSYM` with the inner DWARF binary renamed to
+/// `<framework_name>` so xcodebuild can match it to the framework slice and
+/// drop it into `<slice>/dSYMs/` with the canonical name Xcode/App Store
+/// Connect expects.
+fn prepare_target_dsym(
+    target: &Target,
+    lib_name: &str,
+    framework_name: &str,
+    mode: Mode,
+    staging_dir: &Path,
+) -> Result<PathBuf> {
+    let arches = target.architectures();
+    let per_arch_dsyms: Vec<PathBuf> = arches
+        .iter()
+        .map(|arch| arch_dsym_path(arch, lib_name, mode))
+        .collect();
+
+    let missing: Vec<&PathBuf> = per_arch_dsyms.iter().filter(|p| !p.exists()).collect();
+    if !missing.is_empty() {
+        return Err(anyhow!(
+            "--debug-symbols was passed but no .dSYM was found for target '{}'.\n\
+             Expected dSYMs at:\n  {}\n\
+             Enable debug info on the Cargo profile, e.g. add to [profile.{}]:\n\
+                 debug = \"limited\"\n\
+                 split-debuginfo = \"packed\"",
+            target.display_name(),
+            missing
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join("\n  "),
+            match mode {
+                Mode::Debug => "dev",
+                Mode::Release => "release",
+            },
+        )
+        .into());
+    }
+
+    let src_dwarf_name = library_file_name(lib_name, LibType::Dynamic);
+    // Per-target subdir avoids collisions when multiple targets stage a
+    // `<framework_name>.framework.dSYM` simultaneously.
+    let target_key = match target {
+        Target::Universal { universal_name, .. } => (*universal_name).to_string(),
+        Target::Single { architecture, .. } => (*architecture).to_string(),
+    };
+    let staged = staging_dir
+        .join(target_key)
+        .join(format!("{framework_name}.framework.dSYM"));
+    if staged.exists() {
+        remove_dir_all(&staged)
+            .with_context(|| format!("Failed to clean stale staged dSYM {staged:?}"))?;
+    }
+
+    // Copy the first per-arch dSYM as a template (gives us the bundle wrapper,
+    // Info.plist, and resource layout). We then rename the DWARF Mach-O and
+    // (for universal targets) overwrite it with the lipo'd fat binary.
+    copy_dir_recursively(&per_arch_dsyms[0], &staged)
+        .with_context(|| format!("Failed to stage dSYM from {:?}", per_arch_dsyms[0]))?;
+
+    let dwarf_dir = staged.join("Contents/Resources/DWARF");
+    let staged_dwarf_src = dwarf_dir.join(&src_dwarf_name);
+    let staged_dwarf_dst = dwarf_dir.join(framework_name);
+    if staged_dwarf_src.exists() {
+        fs::rename(&staged_dwarf_src, &staged_dwarf_dst).with_context(|| {
+            format!(
+                "Failed to rename DWARF Mach-O from {staged_dwarf_src:?} to {staged_dwarf_dst:?}"
+            )
+        })?;
+    }
+
+    if per_arch_dsyms.len() > 1 {
+        let mut lipo = Command::new("lipo");
+        for d in &per_arch_dsyms {
+            lipo.arg(d.join("Contents/Resources/DWARF").join(&src_dwarf_name));
+        }
+        lipo.arg("-create").arg("-output").arg(&staged_dwarf_dst);
+
+        let lipo_out = lipo
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .context("Failed to invoke lipo on dSYM DWARF binaries")?;
+        if !lipo_out.status.success() {
+            return Err(anyhow!(
+                "lipo failed combining dSYMs for target '{}': {}",
+                target.display_name(),
+                String::from_utf8_lossy(&lipo_out.stderr)
+            )
+            .into());
+        }
+    }
+
+    Ok(staged)
+}
+
+/// Minimal recursive copy. dSYMs are plain directory trees of files and
+/// (occasionally) symlinks; no special-casing needed for Resource forks etc.
+fn copy_dir_recursively(src: &Path, dst: &Path) -> Result<()> {
+    fs::create_dir_all(dst).with_context(|| format!("Failed to create {dst:?}"))?;
+    for entry in fs::read_dir(src).with_context(|| format!("Failed to read {src:?}"))? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let dst_entry = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursively(&entry.path(), &dst_entry)?;
+        } else if file_type.is_symlink() {
+            let link_target = fs::read_link(entry.path())?;
+            symlink(link_target, &dst_entry).with_context(|| {
+                format!("Failed to recreate symlink at {dst_entry:?}")
+            })?;
+        } else {
+            fs::copy(entry.path(), &dst_entry).with_context(|| {
+                format!("Failed to copy {:?} → {dst_entry:?}", entry.path())
+            })?;
+        }
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn create_xcframework(
     targets: &[Target],
@@ -316,12 +460,30 @@ pub fn create_xcframework(
     lib_type: LibType,
     privacy_manifest: Option<&Path>,
     bundle_identifier: Option<&str>,
+    debug_symbols: bool,
 ) -> Result<()> {
     let output_dir_name = &output_dir
         .to_str()
         .ok_or(anyhow!("Output directory has an invalid name!"))?;
 
     let framework = format!("{output_dir_name}/{xcframework_name}.xcframework");
+
+    // Stage dSYMs under cargo's target dir so they're cheaply cleanup-able and
+    // don't pollute the package output. xcodebuild copies them into the
+    // xcframework, so the staging dir is only needed during this invocation.
+    let dsym_staging: Option<PathBuf> = if debug_symbols {
+        let target_dir = metadata().target_dir();
+        let dir = PathBuf::from(format!("{target_dir}/.cargo-swift-dsyms/{xcframework_name}"));
+        if dir.exists() {
+            remove_dir_all(&dir)
+                .with_context(|| format!("Failed to clean stale dSYM staging dir {dir:?}"))?;
+        }
+        fs::create_dir_all(&dir)
+            .with_context(|| format!("Failed to create dSYM staging dir {dir:?}"))?;
+        Some(dir)
+    } else {
+        None
+    };
 
     let mut xcodebuild = Command::new("xcodebuild");
     xcodebuild.arg("-create-xcframework");
@@ -338,11 +500,21 @@ pub fn create_xcframework(
                 .to_str()
                 .ok_or(anyhow!("Directory for bindings has an invalid name!"))?;
 
-            for lib in &libs {
+            for (target, lib) in targets.iter().zip(libs.iter()) {
                 xcodebuild.arg("-library");
                 xcodebuild.arg(lib);
                 xcodebuild.arg("-headers");
                 xcodebuild.arg(headers);
+                if let Some(staging) = &dsym_staging {
+                    let dsym =
+                        prepare_target_dsym(target, lib_name, xcframework_name, mode, staging)?;
+                    // xcodebuild rejects relative paths for -debug-symbols.
+                    let dsym = dsym
+                        .canonicalize()
+                        .with_context(|| format!("Failed to canonicalize dSYM {dsym:?}"))?;
+                    xcodebuild.arg("-debug-symbols");
+                    xcodebuild.arg(&dsym);
+                }
             }
         }
         LibType::Dynamic => {
@@ -372,6 +544,16 @@ pub fn create_xcframework(
 
                 xcodebuild.arg("-framework");
                 xcodebuild.arg(&fw_path);
+                if let Some(staging) = &dsym_staging {
+                    let dsym =
+                        prepare_target_dsym(target, lib_name, xcframework_name, mode, staging)?;
+                    // xcodebuild rejects relative paths for -debug-symbols.
+                    let dsym = dsym
+                        .canonicalize()
+                        .with_context(|| format!("Failed to canonicalize dSYM {dsym:?}"))?;
+                    xcodebuild.arg("-debug-symbols");
+                    xcodebuild.arg(&dsym);
+                }
             }
         }
     }
@@ -382,6 +564,11 @@ pub fn create_xcframework(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()?;
+
+    // Best-effort cleanup of the staging dir regardless of xcodebuild's outcome.
+    if let Some(staging) = &dsym_staging {
+        let _ = remove_dir_all(staging);
+    }
 
     if !output.status.success() {
         Err(output.stderr.into())

--- a/testing/end-to-end/debug-symbols.swift
+++ b/testing/end-to-end/debug-symbols.swift
@@ -1,0 +1,189 @@
+#!/usr/bin/env swift
+import Foundation
+
+func error(_ msg: String) { FileHandle.standardError.write(msg.data(using: .utf8)!) }
+func dirExists(atPath path: String) -> Bool {
+    var isDirectory : ObjCBool = true
+    let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+    return exists && isDirectory.boolValue
+}
+func fileExists(atPath path: String) -> Bool {
+    var isDirectory : ObjCBool = true
+    let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+    return exists && !isDirectory.boolValue
+}
+
+/// Run a process to completion, capture stdout, return as String.
+func capture(_ args: [String]) throws -> String {
+    let p = Process()
+    let pipe = Pipe()
+    p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    p.arguments = args
+    p.standardOutput = pipe
+    p.standardError = Pipe()
+    try p.run()
+    p.waitUntilExit()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8) ?? ""
+}
+
+/// Parse `dwarfdump --uuid` output for a Mach-O binary into the set of (UUID, arch)
+/// pairs it contains. Each line looks like:
+///     UUID: 6A8B... (arm64) /path/to/binary
+func uuidsForBinary(at path: String) throws -> Set<String> {
+    let out = try capture(["dwarfdump", "--uuid", path])
+    var ids = Set<String>()
+    for line in out.split(separator: "\n") {
+        // grab "UUID: <hex> (<arch>)"
+        guard let r = line.range(of: #"UUID:\s+([0-9A-Fa-f-]+)\s+\(([^)]+)\)"#, options: .regularExpression)
+        else { continue }
+        let snippet = String(line[r])
+        let parts = snippet.replacingOccurrences(of: "UUID:", with: "").trimmingCharacters(in: .whitespaces)
+        ids.insert(parts)
+    }
+    return ids
+}
+
+let projectName = "swift-project-debug-symbols"
+let libName = "swift_project_debug_symbols"
+let packageName = "SwiftProjectDebugSymbols"
+let ffiModuleName = "DebugSymbolsFFI"
+let xcFrameworkName = ffiModuleName
+
+// Create project
+print("Creating project...")
+let cargoSwiftInit = Process()
+cargoSwiftInit.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+cargoSwiftInit.arguments = ["cargo", "swift", "init", projectName, "-y", "--silent"]
+try! cargoSwiftInit.run()
+cargoSwiftInit.waitUntilExit()
+guard cargoSwiftInit.terminationStatus == 0 else {
+    error("cargo swift init failed with status \(cargoSwiftInit.terminationStatus)")
+    exit(1)
+}
+
+// Switch to cdylib + add the release profile knobs that produce .dSYM bundles
+// (`debug` + `split-debuginfo = packed` runs dsymutil during link on macOS).
+print("Patching Cargo.toml: cdylib + release profile with split-debuginfo...")
+let cargoTomlPath = "\(projectName)/Cargo.toml"
+var cargoToml = try! String(contentsOfFile: cargoTomlPath, encoding: .utf8)
+cargoToml = cargoToml.replacingOccurrences(
+    of: "crate-type = [\"staticlib\", \"lib\"]",
+    with: "crate-type = [\"cdylib\", \"lib\"]"
+)
+cargoToml += """
+
+[profile.release]
+debug = "limited"
+split-debuginfo = "packed"
+"""
+try! cargoToml.write(toFile: cargoTomlPath, atomically: true, encoding: .utf8)
+
+// Add uniffi.toml with custom ffi_module_name so the framework binary name is
+// deterministic (DebugSymbolsFFI) regardless of the crate name munging.
+print("Adding uniffi.toml with custom ffi_module_name...")
+let uniffiToml = """
+[bindings.swift]
+ffi_module_name = "\(ffiModuleName)"
+"""
+FileManager.default.createFile(
+    atPath: "\(projectName)/uniffi.toml",
+    contents: uniffiToml.data(using: .utf8),
+    attributes: nil
+)
+
+// Package as dynamic library with --debug-symbols + --release so the dSYMs end
+// up in dSYMs/ subdirs inside the xcframework.
+print("Running cargo swift package --debug-symbols --release...")
+let cargoSwiftPackage = Process()
+cargoSwiftPackage.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+cargoSwiftPackage.currentDirectoryPath += "/" + projectName
+cargoSwiftPackage.arguments = [
+    "cargo", "swift", "package", "-y", "--silent",
+    "-p", "macos", "ios",
+    "--lib-type", "dynamic",
+    "--release",
+    "--debug-symbols",
+    "--bundle-identifier", "io.test.dsyms.\(ffiModuleName)",
+]
+try! cargoSwiftPackage.run()
+cargoSwiftPackage.waitUntilExit()
+guard cargoSwiftPackage.terminationStatus == 0 else {
+    error("cargo swift package --debug-symbols failed with status \(cargoSwiftPackage.terminationStatus)")
+    exit(1)
+}
+
+let xcframeworkPath = "\(projectName)/\(packageName)/\(xcFrameworkName).xcframework"
+guard dirExists(atPath: xcframeworkPath) else {
+    error("xcframework not produced at \(xcframeworkPath)")
+    exit(1)
+}
+
+let subframeworks = try! FileManager.default.contentsOfDirectory(atPath: xcframeworkPath)
+    .filter { !$0.hasPrefix(".") && $0 != "Info.plist" }
+
+guard !subframeworks.isEmpty else {
+    error("xcframework has no platform slices")
+    exit(1)
+}
+
+// macOS and Mac Catalyst use the versioned bundle layout. All other Apple
+// platforms use the shallow layout — the framework binary path differs.
+func usesVersionedBundle(slice: String) -> Bool {
+    return slice.hasPrefix("macos") || slice.contains("maccatalyst")
+}
+
+// For every slice: verify dSYMs/<framework>.framework.dSYM exists with the
+// expected internal structure, and that its DWARF binary's UUID set matches
+// the framework binary's UUID set so Xcode auto-loads symbols at runtime.
+for subframework in subframeworks {
+    let slicePath = "\(xcframeworkPath)/\(subframework)"
+    let dsymRoot = "\(slicePath)/dSYMs"
+    let dsymBundle = "\(dsymRoot)/\(xcFrameworkName).framework.dSYM"
+    let dsymDwarf = "\(dsymBundle)/Contents/Resources/DWARF/\(xcFrameworkName)"
+    let dsymInfoPlist = "\(dsymBundle)/Contents/Info.plist"
+
+    // 1. dSYMs/ subdir is what xcodebuild -create-xcframework -debug-symbols
+    // produces. If it's missing, the flag never made it through.
+    guard dirExists(atPath: dsymRoot) else {
+        error("\(slicePath): missing dSYMs/ subdir — was -debug-symbols passed?")
+        exit(1)
+    }
+
+    // 2. The dSYM bundle and its inner Mach-O must both exist.
+    guard dirExists(atPath: dsymBundle) else {
+        error("\(slicePath): missing \(xcFrameworkName).framework.dSYM bundle")
+        exit(1)
+    }
+    guard fileExists(atPath: dsymDwarf) else {
+        error("\(slicePath): missing DWARF binary at \(dsymDwarf)")
+        exit(1)
+    }
+    guard fileExists(atPath: dsymInfoPlist) else {
+        error("\(slicePath): missing dSYM Info.plist at \(dsymInfoPlist)")
+        exit(1)
+    }
+
+    // 3. UUID parity. dSYMs are matched to binaries by Mach-O LC_UUID; if the
+    // dSYM's UUID set isn't a superset of the framework binary's, lldb /
+    // App Store Connect can't symbolicate.
+    let versioned = usesVersionedBundle(slice: subframework)
+    let frameworkBinary = versioned
+        ? "\(slicePath)/\(xcFrameworkName).framework/Versions/A/\(xcFrameworkName)"
+        : "\(slicePath)/\(xcFrameworkName).framework/\(xcFrameworkName)"
+    let binaryUUIDs = try uuidsForBinary(at: frameworkBinary)
+    let dsymUUIDs = try uuidsForBinary(at: dsymDwarf)
+    guard !binaryUUIDs.isEmpty else {
+        error("\(slicePath): could not read UUIDs from framework binary \(frameworkBinary)")
+        exit(1)
+    }
+    guard binaryUUIDs.isSubset(of: dsymUUIDs) else {
+        let missing = binaryUUIDs.subtracting(dsymUUIDs).joined(separator: ", ")
+        error("\(slicePath): dSYM is missing UUIDs that the framework binary has: \(missing)")
+        exit(1)
+    }
+
+    print("  \(subframework): dSYM OK, UUIDs \(dsymUUIDs) cover binary \(binaryUUIDs)")
+}
+
+print("Tests for cargo swift package --debug-symbols passed!")

--- a/testing/end-to-end/debug-symbols.swift
+++ b/testing/end-to-end/debug-symbols.swift
@@ -164,6 +164,21 @@ for subframework in subframeworks {
         exit(1)
     }
 
+    // 2b. CFBundleIdentifier should match the framework's dSYM convention
+    // (com.apple.xcode.dsym.<framework>.framework) — not the raw .dylib name
+    // that cargo's dsymutil emits. Cosmetic but matches what Xcode produces
+    // for archive-built frameworks and what crash-reporter vendors expect.
+    let plist = NSDictionary(contentsOfFile: dsymInfoPlist) as? [String: Any] ?? [:]
+    let expectedID = "com.apple.xcode.dsym.\(xcFrameworkName).framework"
+    guard (plist["CFBundleIdentifier"] as? String) == expectedID else {
+        error("\(slicePath): dSYM CFBundleIdentifier should be \(expectedID), got \(plist["CFBundleIdentifier"] ?? "<nil>")")
+        exit(1)
+    }
+    guard (plist["CFBundlePackageType"] as? String) == "dSYM" else {
+        error("\(slicePath): dSYM CFBundlePackageType should be 'dSYM'")
+        exit(1)
+    }
+
     // 3. UUID parity. dSYMs are matched to binaries by Mach-O LC_UUID; if the
     // dSYM's UUID set isn't a superset of the framework binary's, lldb /
     // App Store Connect can't symbolicate.


### PR DESCRIPTION
## Summary

Adds a `--debug-symbols` flag to `cargo swift package` that embeds `.dSYM` bundles into the
generated xcframework, so crash reports against a release (stripped) dynamic framework can be
symbolicated.

- **Per-slice dSYMs.** Single-arch slices reuse the per-arch `.dSYM` Cargo emits; universal
  slices get a fresh `.dSYM` whose DWARF Mach-O is the `lipo`-combined fat binary of the
  per-arch DWARFs (per-arch UUIDs preserved). Each is renamed to `<framework>.framework.dSYM`
  so `xcodebuild -create-xcframework -debug-symbols` drops it into `<slice>/dSYMs/` under the
  name Xcode and App Store Connect expect.
- **Canonical bundle identifier.** Rewrites the staged dSYM `Info.plist` `CFBundleIdentifier`
  from dsymutil's `com.apple.xcode.dsym.<lib>.dylib` to the `…<framework>.framework` form that
  Xcode-built frameworks use and crash-reporter vendors (Sentry, Crashlytics, Bugsnag) match
  on. Done with `plutil` (ships with macOS, no new crate).

Requires the consuming Cargo profile to actually emit debug info (e.g. `debug = "limited"` +
`split-debuginfo = "packed"` on macOS).

## Testing

New `testing/end-to-end/debug-symbols.swift`, wired into the `end-to-end.yml` matrix: builds a
cdylib with the dSYM-producing profile knobs and `--debug-symbols`, then asserts every slice
has a `dSYMs/<fw>.framework.dSYM` whose UUIDs are a superset of the framework binary's UUIDs
(so lldb can symbolicate at runtime), plus the rewritten identifier and
`CFBundlePackageType=dSYM`.
